### PR TITLE
Bump gogs, jenkins and plugins versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     environment:
       - JAVA_OPTS="-Djenkins.install.runSetupWizard=false"
   gogs:
-    image: gogs/gogs:0.9.97
+    image: gogs/gogs:0.10.18
     volumes:
       - /tmp/gogs/:/data/
     ports:

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins:2.19.4
+FROM jenkins:2.32.3
 
 USER root
 ARG DOCKER_VERSION

--- a/jenkins/plugins.txt
+++ b/jenkins/plugins.txt
@@ -1,8 +1,8 @@
-job-dsl:1.53
-delivery-pipeline-plugin:0.10.2
+job-dsl:1.58
+delivery-pipeline-plugin:0.10.3
 envinject:1.93.1
-git:3.0.1
-gogs-webhook:1.0.7
+git:3.1.0
+gogs-webhook:1.0.9
 ws-cleanup:0.32
-credentials:2.1.10
+credentials:2.1.13
 credentials-binding:1.10

--- a/repositories/jenkins_seed/jjdsl/create_microservice/pipeline.groovy
+++ b/repositories/jenkins_seed/jjdsl/create_microservice/pipeline.groovy
@@ -42,7 +42,7 @@ createRepo.with {
 
       NEW_SERVICE_BUILD_JOB_NAME=${new BuildMicroserviceJobName(serviceName:"\${SERVICE_NAME}").value()}
       curl -f -X POST ${gogs.restApi.authenticatedWebhooksUrl("\${SERVICE_NAME}", "\${GOGS_PASS}")} \\
-        -d "{\\"type\\":\\"gogs\\",\\"config\\":{\\"url\\":\\"http://jenkins:8080/gogs-webhook/?job=\${NEW_SERVICE_BUILD_JOB_NAME}\\",\\"content_type\\":\\"json\\"},\\"active\\":true}" \\
+        -d "{\\"type\\":\\"gogs\\",\\"config\\":{\\"url\\":\\"http://jenkins:8080/gogs-webhook/?job=\${NEW_SERVICE_BUILD_JOB_NAME}\\",\\"content_type\\":\\"json\\",\\"secret\\":\\"dummy\\"},\\"active\\":true}" \\
         -H "Content-type: application/json"
       """.stripIndent()
     )

--- a/run.sh
+++ b/run.sh
@@ -88,10 +88,10 @@ JENKINS_PORT=8080
 JENKINS_HOST_PORT=localhost:${JENKINS_PORT}
 
 curl -f -X POST http://${GOGS_HOST_PORT}/api/v1/repos/${GOGS_USER}/${JENKINS_SEED}/hooks \
-  -d '{"type":"gogs","config":{"url":"http://jenkins:'${JENKINS_PORT}'/gogs-webhook/?job=_seed","content_type":"json"},"active":true}' \
+  -d '{"type":"gogs","config":{"url":"http://jenkins:'${JENKINS_PORT}'/gogs-webhook/?job=_seed","content_type":"json","secret":"dummy"},"active":true}' \
   -H "Content-type: application/json" -u ${GOGS_USER}:${GOGS_PASS}
 curl -f -X POST http://${GOGS_HOST_PORT}/api/v1/repos/${GOGS_USER}/${MICROSERVICE_CODE_GENERATOR}/hooks \
-  -d '{"type":"gogs","config":{"url":"http://jenkins:'${JENKINS_PORT}'/gogs-webhook/?job=microservice_code_generator_build","content_type":"json"},"active":true}' \
+  -d '{"type":"gogs","config":{"url":"http://jenkins:'${JENKINS_PORT}'/gogs-webhook/?job=microservice_code_generator_build","content_type":"json","secret":"dummy"},"active":true}' \
   -H "Content-type: application/json" -u ${GOGS_USER}:${GOGS_PASS}
 
 echo "Creating ${GOGS_USER} secret in jenkins"


### PR DESCRIPTION
New versions of gogs and gogs-webhook plugin require a secret for the hooks. Any dummy secret works.